### PR TITLE
feat: auto-update treb-sol submodule on run command

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/trebuchet-org/treb-cli/cli/pkg/script/executor"
 	"github.com/trebuchet-org/treb-cli/cli/pkg/script/parameters"
 	"github.com/trebuchet-org/treb-cli/cli/pkg/script/parser"
+	"github.com/trebuchet-org/treb-cli/cli/pkg/submodule"
 	"github.com/trebuchet-org/treb-cli/cli/pkg/types"
 )
 
@@ -66,6 +67,20 @@ Examples:
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		scriptPath := args[0]
+
+		// Check and update treb-sol if needed (unless disabled)
+		skipTrebSolUpdate, _ := cmd.Flags().GetBool("skip-treb-sol-update")
+		if !skipTrebSolUpdate {
+			trebSolManager := submodule.NewTrebSolManager(".")
+			if trebSolManager.IsTrebSolInstalled() {
+				// Check for updates in a non-blocking way
+				if err := trebSolManager.CheckAndUpdate(false); err != nil {
+					// This should not happen as CheckAndUpdate handles errors gracefully
+					// but if it does, we just continue with the existing version
+					fmt.Fprintf(os.Stderr, "Warning: Failed to check treb-sol updates: %v\n", err)
+				}
+			}
+		}
 
 		indexer, err := contracts.GetGlobalIndexer(".")
 		if err != nil {
@@ -330,4 +345,7 @@ func init() {
 	runCmd.Flags().Bool("debug", false, "Enable debug mode (shows forge output and saves to file)")
 	runCmd.Flags().Bool("debug-json", false, "Enable JSON debug mode (shows raw JSON output)")
 	runCmd.Flags().BoolP("verbose", "v", false, "Show extra detailed information for events and transactions")
+
+	// Submodule management flags
+	runCmd.Flags().Bool("skip-treb-sol-update", false, "Skip automatic treb-sol update check")
 }

--- a/cli/pkg/submodule/trebsol.go
+++ b/cli/pkg/submodule/trebsol.go
@@ -1,0 +1,208 @@
+package submodule
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	trebSolRepo = "https://github.com/trebuchet-org/treb-sol"
+	trebSolAPI  = "https://api.github.com/repos/trebuchet-org/treb-sol/commits/main"
+)
+
+// TrebSolManager manages the treb-sol submodule version checking and updating
+type TrebSolManager struct {
+	projectRoot string
+}
+
+// NewTrebSolManager creates a new TrebSolManager
+func NewTrebSolManager(projectRoot string) *TrebSolManager {
+	return &TrebSolManager{
+		projectRoot: projectRoot,
+	}
+}
+
+// GetCurrentCommit returns the current commit hash of the treb-sol submodule
+func (m *TrebSolManager) GetCurrentCommit() (string, error) {
+	trebSolPath := m.getTrebSolPath()
+	cmd := exec.Command("git", "submodule", "status", trebSolPath)
+	cmd.Dir = m.projectRoot
+	
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get submodule status: %w", err)
+	}
+	
+	// Parse output: " 38d8164935b41d697db47c99b70c0c45a78ede67 treb-sol (remotes/origin/ignore-collisions)"
+	// or             " 38d8164935b41d697db47c99b70c0c45a78ede67 lib/treb-sol (remotes/origin/ignore-collisions)"
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, trebSolPath) {
+			parts := strings.Fields(line)
+			if len(parts) >= 2 {
+				// Remove leading + or - if present
+				commit := strings.TrimPrefix(parts[0], "+")
+				commit = strings.TrimPrefix(commit, "-")
+				return commit, nil
+			}
+		}
+	}
+	
+	return "", fmt.Errorf("could not find %s in submodule status", trebSolPath)
+}
+
+// GetLatestCommit fetches the latest commit hash from the treb-sol repository
+func (m *TrebSolManager) GetLatestCommit() (string, error) {
+	// Create HTTP client with timeout
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	
+	// Create request
+	req, err := http.NewRequest("GET", trebSolAPI, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	
+	// Add headers
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("User-Agent", "treb-cli")
+	
+	// Make request
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch latest commit: %w", err)
+	}
+	defer resp.Body.Close()
+	
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("GitHub API error (status %d): %s", resp.StatusCode, string(body))
+	}
+	
+	// Parse response
+	var result struct {
+		SHA string `json:"sha"`
+	}
+	
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("failed to parse response: %w", err)
+	}
+	
+	return result.SHA, nil
+}
+
+// IsUpdateAvailable checks if there's a newer version of treb-sol available
+func (m *TrebSolManager) IsUpdateAvailable() (bool, string, string, error) {
+	current, err := m.GetCurrentCommit()
+	if err != nil {
+		return false, "", "", fmt.Errorf("failed to get current commit: %w", err)
+	}
+	
+	latest, err := m.GetLatestCommit()
+	if err != nil {
+		return false, "", "", fmt.Errorf("failed to get latest commit: %w", err)
+	}
+	
+	return current != latest, current, latest, nil
+}
+
+// Update updates the treb-sol submodule to the latest version
+func (m *TrebSolManager) Update() error {
+	trebSolPath := m.getTrebSolPath()
+	
+	// First, fetch the latest changes
+	cmd := exec.Command("git", "submodule", "update", "--init", "--remote", trebSolPath)
+	cmd.Dir = m.projectRoot
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to update submodule: %w", err)
+	}
+	
+	return nil
+}
+
+// CheckAndUpdate checks for updates and updates if available
+func (m *TrebSolManager) CheckAndUpdate(silent bool) error {
+	hasUpdate, current, latest, err := m.IsUpdateAvailable()
+	if err != nil {
+		// In case of network error or API issues, just print warning
+		if !silent {
+			fmt.Fprintf(os.Stderr, "Warning: Could not check for treb-sol updates: %v\n", err)
+		}
+		return nil // Don't fail the command
+	}
+	
+	if !hasUpdate {
+		return nil
+	}
+	
+	if !silent {
+		fmt.Printf("Updating treb-sol from %s to %s...\n", current[:7], latest[:7])
+	}
+	
+	if err := m.Update(); err != nil {
+		if !silent {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to update treb-sol to latest version: %v\n", err)
+			fmt.Fprintf(os.Stderr, "You may need to manually update treb-sol by running: git submodule update --init --remote treb-sol\n")
+		}
+		return nil // Don't fail the command
+	}
+	
+	if !silent {
+		fmt.Println("Successfully updated treb-sol to latest version")
+	}
+	
+	return nil
+}
+
+// IsTrebSolInstalled checks if treb-sol is properly installed as a submodule
+func (m *TrebSolManager) IsTrebSolInstalled() bool {
+	// Check in treb-cli repo location (for treb development)
+	trebSolPath := filepath.Join(m.projectRoot, "treb-sol")
+	if m.isValidSubmodule(trebSolPath) {
+		return true
+	}
+	
+	// Check in user project location (lib/treb-sol)
+	libTrebSolPath := filepath.Join(m.projectRoot, "lib", "treb-sol")
+	return m.isValidSubmodule(libTrebSolPath)
+}
+
+// isValidSubmodule checks if a path is a valid git submodule
+func (m *TrebSolManager) isValidSubmodule(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	
+	// Check if it's a directory and has .git file/folder (submodule indicator)
+	if !info.IsDir() {
+		return false
+	}
+	
+	gitPath := filepath.Join(path, ".git")
+	_, err = os.Stat(gitPath)
+	return err == nil
+}
+
+// getTrebSolPath returns the path to treb-sol submodule
+func (m *TrebSolManager) getTrebSolPath() string {
+	// Check in treb-cli repo location first
+	trebSolPath := filepath.Join(m.projectRoot, "treb-sol")
+	if m.isValidSubmodule(trebSolPath) {
+		return "treb-sol"
+	}
+	
+	// Fall back to user project location
+	return "lib/treb-sol"
+}

--- a/cli/pkg/submodule/trebsol_test.go
+++ b/cli/pkg/submodule/trebsol_test.go
@@ -1,0 +1,50 @@
+package submodule
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTrebSolManager(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "treb-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	manager := NewTrebSolManager(tempDir)
+
+	t.Run("IsTrebSolInstalled_NotInstalled", func(t *testing.T) {
+		if manager.IsTrebSolInstalled() {
+			t.Error("Expected IsTrebSolInstalled to return false for empty directory")
+		}
+	})
+
+	t.Run("IsTrebSolInstalled_MockInstalled", func(t *testing.T) {
+		// Create mock treb-sol directory with .git
+		trebSolPath := filepath.Join(tempDir, "lib", "treb-sol")
+		if err := os.MkdirAll(trebSolPath, 0755); err != nil {
+			t.Fatalf("Failed to create treb-sol dir: %v", err)
+		}
+		
+		// Create .git file (submodule indicator)
+		gitPath := filepath.Join(trebSolPath, ".git")
+		if err := os.WriteFile(gitPath, []byte("gitdir: ../../.git/modules/lib/treb-sol"), 0644); err != nil {
+			t.Fatalf("Failed to create .git file: %v", err)
+		}
+
+		if !manager.IsTrebSolInstalled() {
+			t.Error("Expected IsTrebSolInstalled to return true for valid submodule")
+		}
+	})
+
+	t.Run("GetTrebSolPath", func(t *testing.T) {
+		// Should return lib/treb-sol by default
+		path := manager.getTrebSolPath()
+		if path != "lib/treb-sol" {
+			t.Errorf("Expected getTrebSolPath to return 'lib/treb-sol', got '%s'", path)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Implements automatic checking and updating of the treb-sol submodule when running `treb run`
- Ensures users always have the latest version of treb-sol before executing scripts
- Adds graceful error handling with warnings instead of failures

## Changes
- Added `TrebSolManager` in `cli/pkg/submodule/trebsol.go` to handle version checking and updates
- Modified `run` command to check and update treb-sol before execution
- Added `--skip-treb-sol-update` flag to allow users to skip auto-update if needed
- Handles both treb-cli repo layout (`treb-sol/`) and user project layout (`lib/treb-sol/`)

## Test plan
- [x] Unit tests for TrebSolManager functionality
- [x] Manual testing of run command with outdated treb-sol
- [x] Verify --skip-treb-sol-update flag works
- [x] Test with network errors (graceful degradation)

🤖 Generated with [Claude Code](https://claude.ai/code)