### PR TITLE
feat: display console.log statements after treb run execution

### DIFF
--- a/cli/pkg/forge/script.go
+++ b/cli/pkg/forge/script.go
@@ -342,7 +342,7 @@ func (f *Forge) extractConsoleLogs(logs []string) []string {
 func (f *Forge) extractConsoleLogsFromText(textOutput string) []string {
 	var consoleLogs []string
 	lines := strings.Split(textOutput, "\n")
-	
+
 	for _, line := range lines {
 		// Look for common patterns in forge output for console logs
 		if strings.Contains(line, "Logs:") {
@@ -359,7 +359,7 @@ func (f *Forge) extractConsoleLogsFromText(textOutput string) []string {
 			consoleLogs = append(consoleLogs, strings.TrimSpace(line))
 		}
 	}
-	
+
 	return consoleLogs
 }
 

--- a/cli/pkg/forge/script.go
+++ b/cli/pkg/forge/script.go
@@ -102,8 +102,8 @@ func (f *Forge) Run(opts ScriptOptions) (*ScriptResult, error) {
 		case "ScriptOutput":
 			if output, ok := entity.Data.(ScriptOutput); ok {
 				parsedOutput.ScriptOutput = &output
-				// Extract console logs
-				parsedOutput.ConsoleLogs = append(parsedOutput.ConsoleLogs, f.extractConsoleLogs(output.Logs)...)
+				// Console logs are already in output.Logs
+				parsedOutput.ConsoleLogs = append(parsedOutput.ConsoleLogs, output.Logs...)
 			}
 		case "GasEstimate":
 			if gas, ok := entity.Data.(GasEstimate); ok {
@@ -155,6 +155,12 @@ func (f *Forge) Run(opts ScriptOptions) (*ScriptResult, error) {
 	// Set results
 	result.RawOutput = outputBuffer.Bytes()
 	result.ParsedOutput = parsedOutput
+
+	// Extract console logs from text output if not already in ConsoleLogs
+	if parsedOutput.TextOutput != "" {
+		additionalLogs := f.extractConsoleLogsFromText(parsedOutput.TextOutput)
+		parsedOutput.ConsoleLogs = append(parsedOutput.ConsoleLogs, additionalLogs...)
+	}
 
 	// Print text output if script failed or in debug/verbose mode
 	if parsedOutput.TextOutput != "" && (result.Error != nil || opts.Debug) {
@@ -329,6 +335,31 @@ func (f *Forge) extractConsoleLogs(logs []string) []string {
 			consoleLogs = append(consoleLogs, log)
 		}
 	}
+	return consoleLogs
+}
+
+// extractConsoleLogsFromText extracts console.log messages from text output
+func (f *Forge) extractConsoleLogsFromText(textOutput string) []string {
+	var consoleLogs []string
+	lines := strings.Split(textOutput, "\n")
+	
+	for _, line := range lines {
+		// Look for common patterns in forge output for console logs
+		if strings.Contains(line, "Logs:") {
+			// Extract the actual log message
+			parts := strings.SplitN(line, "Logs:", 2)
+			if len(parts) == 2 {
+				logMsg := strings.TrimSpace(parts[1])
+				if logMsg != "" {
+					consoleLogs = append(consoleLogs, logMsg)
+				}
+			}
+		} else if strings.Contains(line, "console.log") {
+			// Some versions might show console.log differently
+			consoleLogs = append(consoleLogs, strings.TrimSpace(line))
+		}
+	}
+	
 	return consoleLogs
 }
 

--- a/cli/pkg/script/display/display.go
+++ b/cli/pkg/script/display/display.go
@@ -81,9 +81,6 @@ func (d *Display) SetRegistryResolver(registryManager *registry.Manager, chainID
 
 // DisplayExecution displays the complete script execution
 func (d *Display) DisplayExecution() {
-	// Display logs first
-	d.DisplayLogs(d.execution.Logs)
-
 	// Register deployed contracts and proxy relationships
 	d.registerDeployments(d.execution)
 
@@ -92,6 +89,9 @@ func (d *Display) DisplayExecution() {
 
 	// Display execution summary
 	d.printExecutionSummary()
+
+	// Display logs last so they appear after the execution
+	d.DisplayLogs(d.execution.Logs)
 }
 
 // DisplayLogs displays console.log output from the script
@@ -106,6 +106,8 @@ func (d *Display) DisplayLogs(logs []string) {
 	for _, log := range logs {
 		fmt.Printf("  %s\n", log)
 	}
+	
+	fmt.Println() // Add newline after logs for consistent spacing
 }
 
 // registerDeployments registers deployed contracts and proxy relationships

--- a/cli/pkg/script/display/display.go
+++ b/cli/pkg/script/display/display.go
@@ -106,7 +106,7 @@ func (d *Display) DisplayLogs(logs []string) {
 	for _, log := range logs {
 		fmt.Printf("  %s\n", log)
 	}
-	
+
 	fmt.Println() // Add newline after logs for consistent spacing
 }
 


### PR DESCRIPTION
## Summary
- Enhanced `treb run` command to display all console.log statements from forge script execution
- Console logs now appear after the deployment summary for better visibility
- Fixed issue where only the first console.log was being displayed

## Changes
1. Modified display order in `display.go` to show logs after transactions and deployment summary
2. Fixed log extraction in `script.go` to properly use already-parsed logs from ScriptOutput
3. Added consistent spacing between output sections

## Test plan
- [x] Created test script with multiple console.log statements
- [x] Verified all logs are displayed correctly after deployment summary
- [x] Confirmed proper spacing between sections

## Example output
```
📦 Deployment Summary:
──────────────────────────────────────────────────
Counter at 0x0B7e07021DfDD656712c12689d3163300f3e8c53

📝 Script Logs:
────────────────────────────────────────
  Starting test script execution
  This is a test of console.log functionality
  Value is: 42
  Test address: 0x1234567890123456789012345678901234567890
  Script execution completed successfully

✓ Script execution completed successfully
```

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Console logs are now extracted more accurately from output and displayed after all other execution details.
  * Enhanced visual separation with added spacing after logs for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->