### PR TITLE
feat: enhance compose with state management and resume capability

### DIFF
--- a/internal/adapters/progress/compose_progress.go
+++ b/internal/adapters/progress/compose_progress.go
@@ -39,6 +39,14 @@ func (p *ComposeProgress) OnProgress(ctx context.Context, event usecase.Progress
 			p.planRendered = true
 		}
 
+	case "compose_resumed":
+		// Show resume message
+		if resumeInfo, ok := event.Metadata.(map[string]interface{}); ok {
+			fromStep := resumeInfo["from_step"].(int)
+			total := resumeInfo["total"].(int)
+			fmt.Fprintf(p.composeRenderer.GetWriter(), "\n📂 Resuming compose from step %d of %d\n", fromStep+1, total)
+		}
+
 	case "step_starting":
 		// Show step header when starting a new step
 		if stepInfo, ok := event.Metadata.(map[string]interface{}); ok {

--- a/test/integration/compose_resume_test.go
+++ b/test/integration/compose_resume_test.go
@@ -1,0 +1,47 @@
+package integration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/trebuchet-org/treb-cli/test/helpers"
+)
+
+func TestComposeResume(t *testing.T) {
+	tests := []IntegrationTest{
+		{
+			Name: "compose_with_failure_and_resume",
+			PreSetup: func(t *testing.T, ctx *helpers.TestContext) {
+				// Set env var to make the flaky deployment fail
+				os.Setenv("FLAKY_SHOULD_FAIL", "true")
+			},
+			TestCmds: [][]string{
+				// First command will fail
+				s("compose compose-resume-test.yaml --network anvil-31337"),
+			},
+			ExpectErr: true,
+			PostTest: func(t *testing.T, ctx *helpers.TestContext, output string) {
+				assert.Contains(t, output, "Starting Step1")
+				assert.Contains(t, output, "Starting Step2")
+				assert.Contains(t, output, "failed") // Either "Deployment intentionally failed" or "step 'Step2' failed"
+				assert.NotContains(t, output, "Starting Step3")
+
+				// Now unset the env var for the resume test
+				os.Unsetenv("FLAKY_SHOULD_FAIL")
+
+				// Run with resume
+				resumeOutput, err := ctx.TrebContext.Treb("compose", "compose-resume-test.yaml", "--network", "anvil-31337", "--resume")
+				assert.NoError(t, err, "Expected resumed compose run to succeed")
+				assert.Contains(t, resumeOutput, "Resuming compose from step 2 of 3")
+				assert.Contains(t, resumeOutput, "🎉 Successfully orchestrated ResumeTest deployment")
+			},
+			OutputArtifacts: []string{
+				".treb/deployments.json",
+				"out/.treb/compose-compose-resume-test.json",
+			},
+		},
+	}
+
+	RunIntegrationTests(t, tests)
+}

--- a/test/testdata/golden/integration/TestComposeCommand/help/commands.golden
+++ b/test/testdata/golden/integration/TestComposeCommand/help/commands.golden
@@ -48,4 +48,5 @@ Flags:
   -n, --network string     Network to deploy to (local, sepolia, mainnet, etc.)
       --non-interactive    Disable interactive prompts (always non-interactive for orchestration)
       --profile string     Foundry profile to use (overrides namespace-based profile)
+      --resume             Resume from a previous failed or interrupted compose run
   -v, --verbose            Show extra detailed information for events and transactions

--- a/test/testdata/golden/integration/TestComposeCommand/without_config/commands.golden
+++ b/test/testdata/golden/integration/TestComposeCommand/without_config/commands.golden
@@ -1,25 +1,2 @@
 === cmd 0: [compose nonexistent.yaml] ===
 Error: failed to parse orchestration file: failed to read file: open nonexistent.yaml: no such file or directory
-Usage:
-  treb compose <compose-file> [flags]
-
-Examples:
-  # Execute orchestration from YAML file
-  treb compose deploy.yaml
-
-  # Execute with specific network and dry run
-  treb compose deploy.yaml --network sepolia --dry-run
-
-  # Execute with debug output
-  treb compose deploy.yaml --debug --verbose
-
-Flags:
-      --debug              Enable debug mode (shows forge output and saves to file)
-      --debug-json         Enable JSON debug mode (shows raw JSON output)
-      --dry-run            Perform a dry run without broadcasting transactions
-  -h, --help               help for compose
-  -s, --namespace string   Deployment namespace (default, staging, production) [also sets foundry profile]
-  -n, --network string     Network to deploy to (local, sepolia, mainnet, etc.)
-      --non-interactive    Disable interactive prompts (always non-interactive for orchestration)
-      --profile string     Foundry profile to use (overrides namespace-based profile)
-  -v, --verbose            Show extra detailed information for events and transactions

--- a/test/testdata/golden/integration/TestComposeResume/compose_with_failure_and_resume/commands.golden
+++ b/test/testdata/golden/integration/TestComposeResume/compose_with_failure_and_resume/commands.golden
@@ -1,0 +1,103 @@
+=== cmd 0: [compose compose-resume-test.yaml --network anvil-31337] ===
+
+🎯 Orchestrating ResumeTest
+📋 Execution plan: 3 components
+
+📋 Execution Plan:
+──────────────────────────────────────────────────
+1. Step1 → DeployUCProxy
+   Env: map[label:step1]
+2. Step2 → DeployFlaky (depends on: [Step1])
+   Env: map[FLAKY_LABEL:step2]
+3. Step3 → DeployUCProxy (depends on: [Step2])
+   Env: map[label:step3]
+
+
+[1/3] Starting Step1
+
+🚀 Running Deployment Script
+──────────────────────────────────────────────────
+  Script:    DeployerUCProxy
+  Network:   anvil-31337 (31337)
+  Namespace: default
+  Mode:      LIVE
+  Env Vars:  label=step1
+  Senders:   [anvil]
+──────────────────────────────────────────────────
+✓ Step completed successfully
+  Created 2 deployment(s)
+
+🔄 Transactions:
+──────────────────────────────────────────────────
+
+executed  anvil → CreateX::deployCreate3(salt: 0xf39fd6e5..., initCode: 0x60806040...)
+├─ new 0xdbDE0B3963c769bb7b9966827E3bA90C0eDfEcAF()
+│  └─ [return] 0xdbDE0B3963c769bb7b9966827E3bA90C0eDfEcAF
+├─ Create3ProxyContractCreation(newContract: 0xdbDE...EcAF, salt: 0x5fc0b6f0...)
+├─ 0xdbDE0B3963c769bb7b9966827E3bA90C0eDfEcAF::unknown()
+│  └─ 🚀 new UpgradeableCounter()
+│     └─ [return] 0xcFd84621988A8243EfEd4C30163d85f5dEdE07Ad
+└─ ContractCreation(newContract: UpgradeableCounter: [0xcFd846...)
+   Tx: 0x<HASH> | Block: 1 | Gas: 476959
+
+executed  anvil → CreateX::deployCreate3(salt: 0xf39fd6e5..., initCode: 0x60806040...)
+├─ new 0xE0f564003F747e7BF151cbB75fe5d3f4A6f8077d()
+│  └─ [return] 0xE0f564003F747e7BF151cbB75fe5d3f4A6f8077d
+├─ Create3ProxyContractCreation(newContract: 0xE0f5...077d, salt: 0x978e20a9...)
+├─ 0xE0f564003F747e7BF151cbB75fe5d3f4A6f8077d::unknown()
+│  └─ 🚀 new ERC1967Proxy(
+│     │    implementation:: 0xcFd84621988A8243EfEd4C30163d85f5dEdE07Ad,
+│     │    _data:: 0xc4d66de8000000000000000000000000...(36 bytes)
+│     │  )
+│     ├─ Upgraded(implementation: UpgradeableCounter: [0xcFd846...)
+│     ├─ UpgradeableCounter::initialize(initialOwner: 0xf39F...2266)
+│     └─ [return] 0x067887F5245C17228A4d579991bd398De552c6Bb
+└─ ContractCreation(newContract: ERC1967Proxy: [0x067887F5245C...)
+   Tx: 0x<HASH> | Block: 2 | Gas: 207703
+
+executed  anvil → ERC1967Proxy::unknown()
+└─ UpgradeableCounter::increment()
+   └─ CountIncremented(newCount: 1)
+   Tx: 0x<HASH> | Block: 2 | Gas: 51985
+
+📦 Deployment Summary:
+──────────────────────────────────────────────────
+UpgradeableCounter at 0xcFd84621988A8243EfEd4C30163d85f5dEdE07Ad
+ERC1967Proxy:step1[UpgradeableCounter] at 0x067887F5245C17228A4d579991bd398De552c6Bb
+
+
+📝 Script Logs:
+────────────────────────────────────────
+  Registry: failed to load registry from .treb/registry.json
+
+✓ Updated registry for anvil-31337 network in namespace default
+
+[2/3] Starting Step2
+
+🚀 Running Deployment Script
+──────────────────────────────────────────────────
+  Script:    DeployFlaky
+  Network:   anvil-31337 (31337)
+  Namespace: default
+  Mode:      LIVE
+  Env Vars:  FLAKY_LABEL=step2
+  Senders:   [anvil]
+──────────────────────────────────────────────────
+
+📝 Forge Output:
+──────────────────────────────────────────────────
+Error: script failed: Deployment intentionally failed for testing
+──────────────────────────────────────────────────
+
+🔄 Transactions:
+──────────────────────────────────────────────────
+No transactions executed (dry run or all deployments skipped)
+
+══════════════════════════════════════════════════════════════════════
+❌ Orchestration failed
+
+📊 Summary:
+  • Failed at step: Step2
+  • Steps completed: 1/3
+  • Error: step 'Step2' failed
+Error: compose failed: step 'Step2' failed

--- a/test/testdata/golden/integration/TestComposeResume/compose_with_failure_and_resume/compose-compose-resume-test.json.golden
+++ b/test/testdata/golden/integration/TestComposeResume/compose_with_failure_and_resume/compose-compose-resume-test.json.golden
@@ -1,0 +1,70 @@
+{
+  "started_at": "<TIMESTAMP>",
+  "updated_at": "<TIMESTAMP>",
+  "config_path": "compose-resume-test.yaml",
+  "network": "anvil-31337",
+  "namespace": "default",
+  "plan": {
+    "Group": "ResumeTest",
+    "Components": [
+      {
+        "Name": "Step1",
+        "Script": "DeployUCProxy",
+        "Env": {
+          "label": "step1"
+        },
+        "Dependencies": null
+      },
+      {
+        "Name": "Step2",
+        "Script": "DeployFlaky",
+        "Env": {
+          "FLAKY_LABEL": "step2"
+        },
+        "Dependencies": [
+          "Step1"
+        ]
+      },
+      {
+        "Name": "Step3",
+        "Script": "DeployUCProxy",
+        "Env": {
+          "label": "step3"
+        },
+        "Dependencies": [
+          "Step2"
+        ]
+      }
+    ]
+  },
+  "executed_steps": {
+    "Step1": {
+      "step": {
+        "Name": "Step1",
+        "Script": "DeployUCProxy",
+        "Env": {
+          "label": "step1"
+        },
+        "Dependencies": null
+      },
+      "success": true,
+      "deployments": 2
+    },
+    "Step2": {
+      "step": {
+        "Name": "Step2",
+        "Script": "DeployFlaky",
+        "Env": {
+          "FLAKY_LABEL": "step2"
+        },
+        "Dependencies": [
+          "Step1"
+        ]
+      },
+      "success": false
+    }
+  },
+  "current_step_index": 1,
+  "status": "failed",
+  "total_deployments": 2
+}

--- a/test/testdata/golden/integration/TestComposeResume/compose_with_failure_and_resume/deployments.json.golden
+++ b/test/testdata/golden/integration/TestComposeResume/compose_with_failure_and_resume/deployments.json.golden
@@ -1,0 +1,70 @@
+{
+  "default/31337/ERC1967Proxy:step1": {
+    "id": "default/31337/ERC1967Proxy:step1",
+    "namespace": "default",
+    "chainId": 31337,
+    "contractName": "ERC1967Proxy",
+    "label": "step1",
+    "address": "0x067887F5245C17228A4d579991bd398De552c6Bb",
+    "type": "PROXY",
+    "transactionId": "tx-<ID>",
+    "deploymentStrategy": {
+      "method": "CREATE3",
+      "salt": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb922660003594a4edd909aa263944d",
+      "initCodeHash": "0x1b1bda4cab6a3d7fa38599ee084a2fd12b84842c49725b8ccb3fbfe02448ecfc",
+      "factory": "0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed",
+      "constructorArgs": "0x000000000000000000000000cfd84621988a8243efed4c30163d85f5dede07ad00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000024c4d66de8000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb9226600000000000000000000000000000000000000000000000000000000",
+      "entropy": "default/ERC1967Proxy:step1"
+    },
+    "proxyInfo": {
+      "type": "UUPS",
+      "implementation": "0xcFd84621988A8243EfEd4C30163d85f5dEdE07Ad",
+      "history": []
+    },
+    "artifact": {
+      "path": "lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol",
+      "compilerVersion": "0.8.30+commit.73712a01",
+      "bytecodeHash": "0xbbd3799951bbce5d0fef3d4d0ac7b51275f4d7074313155014017539b08c3565",
+      "scriptPath": "script/DeployUCProxy.s.sol",
+      "gitCommit": ""
+    },
+    "verification": {
+      "status": "UNVERIFIED"
+    },
+    "tags": null,
+    "createdAt": "<TIMESTAMP>",
+    "updatedAt": "<TIMESTAMP>"
+  },
+  "default/31337/UpgradeableCounter": {
+    "id": "default/31337/UpgradeableCounter",
+    "namespace": "default",
+    "chainId": 31337,
+    "contractName": "UpgradeableCounter",
+    "label": "",
+    "address": "0xcFd84621988A8243EfEd4C30163d85f5dEdE07Ad",
+    "type": "SINGLETON",
+    "transactionId": "tx-<ID>",
+    "deploymentStrategy": {
+      "method": "CREATE3",
+      "salt": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266008833bca0ee959b6584eba6",
+      "initCodeHash": "0xfcc1922208e5b41b9e53337bcfbe88b2aac805f91b20464d7c3e90ae9fa5766d",
+      "factory": "0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed",
+      "constructorArgs": "0x",
+      "entropy": "default/UpgradeableCounter"
+    },
+    "proxyInfo": null,
+    "artifact": {
+      "path": "src/UpgradeableCounter.sol",
+      "compilerVersion": "0.8.30+commit.73712a01",
+      "bytecodeHash": "0xfcc1922208e5b41b9e53337bcfbe88b2aac805f91b20464d7c3e90ae9fa5766d",
+      "scriptPath": "script/DeployUCProxy.s.sol",
+      "gitCommit": ""
+    },
+    "verification": {
+      "status": "UNVERIFIED"
+    },
+    "tags": null,
+    "createdAt": "<TIMESTAMP>",
+    "updatedAt": "<TIMESTAMP>"
+  }
+}

--- a/test/testdata/project/compose-resume-test.yaml
+++ b/test/testdata/project/compose-resume-test.yaml
@@ -1,0 +1,18 @@
+group: ResumeTest
+components:
+  Step1:
+    script: DeployUCProxy
+    env:
+      label: step1
+  Step2:
+    script: DeployFlaky
+    deps:
+      - Step1
+    env:
+      FLAKY_LABEL: step2
+  Step3:
+    script: DeployUCProxy
+    env:
+      label: step3
+    deps:
+      - Step2

--- a/test/testdata/project/script/DeployFlaky.s.sol
+++ b/test/testdata/project/script/DeployFlaky.s.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {TrebScript} from "treb-sol/src/TrebScript.sol";
+import {Counter} from "src/Counter.sol";
+import {Senders} from "treb-sol/src/internal/sender/Senders.sol";
+import {Deployer} from "treb-sol/src/internal/sender/Deployer.sol";
+
+/**
+ * @notice Deployment script that can be controlled to fail via environment variable
+ * @dev Uses FLAKY_SHOULD_FAIL env var to determine if deployment should revert
+ * @custom:senders anvil
+ */
+contract DeployFlaky is TrebScript {
+    using Senders for Senders.Sender;
+    using Deployer for Senders.Sender;
+    using Deployer for Deployer.Deployment;
+
+    /// @custom:senders anvil
+    function run() public broadcast {
+        // Read the environment variable to determine if we should fail
+        Senders.Sender storage deployer = sender("anvil");
+        bool shouldFail = vm.envOr("FLAKY_SHOULD_FAIL", false);
+
+        if (shouldFail) {
+            revert("Deployment intentionally failed for testing");
+        }
+
+        deployer.create3("UpgradeableCounter").deploy();
+    }
+}
+


### PR DESCRIPTION
## Summary

This PR enhances the compose functionality with proper error handling, state management, and the ability to resume failed compose runs.

## Changes

### 1. **Fixed compose to stop on step failure** ✅
- The compose now properly checks both `stepResult.Error` and `stepResult.RunResult.Success`
- If a step has `Success = false` but no error, an explicit error is created
- The compose command now returns a non-zero exit code when execution fails

### 2. **State file per compose YAML** ✅
- State files are now named based on the compose YAML file to prevent overwrites
- Pattern: `out/.treb/compose-<yaml-name>.json`
- Example: `compose-resume-test.yaml` → `compose-compose-resume-test.json`

### 3. **State management and resume functionality** ✅
- Comprehensive state tracking with execution plan, current step, and results
- State is saved after each step and on failure
- Added `--resume` flag to continue from the last incomplete step
- Resume validates the same config file is being used

### 4. **Optimized state storage** ✅
- Created lightweight `StepStateInfo` struct for state persistence
- Excludes heavy `RunResult` data (artifacts, bytecode, etc.)
- Significantly reduces state file size while preserving essential information

### 5. **Integration tests** ✅
- Added comprehensive integration test for compose resume functionality
- Uses a "flaky" deployment script controlled by environment variable
- Tests failure, state persistence, and successful resume
- Captures state files as golden artifacts

## Testing

The PR includes integration tests that:
1. Run a compose that fails at Step2 (using `FLAKY_SHOULD_FAIL` env var)
2. Verify the state file is created with failed status
3. Resume the compose with the env var unset
4. Verify successful completion from the failed step

## Example Usage

```bash
# Run compose (may fail)
treb compose deploy.yaml --network sepolia

# If it failed, resume from where it left off
treb compose deploy.yaml --network sepolia --resume
```

## State File Example

State files are saved to `out/.treb/compose-<yaml-name>.json` with minimal data:

```json
{
  "status": "failed",
  "current_step_index": 1,
  "executed_steps": {
    "Step1": {
      "success": true,
      "deployments": 1
    },
    "Step2": {
      "success": false,
      "error": "step 'Step2' failed"
    }
  }
}
```

🤖 Generated with [Claude Code](https://claude.ai/code)