### PR TITLE
refactor: remove addressbook from treb list

### DIFF
--- a/internal/app/wire_gen.go
+++ b/internal/app/wire_gen.go
@@ -48,7 +48,7 @@ func InitApp(v *viper.Viper, cmd *cobra.Command) (*App, error) {
 	networkResolver := config.ProvideNetworkResolver(runtimeConfig)
 	forkStateStoreAdapter := fs.NewForkStateStoreAdapter(runtimeConfig)
 	addressbookStoreAdapter := fs.NewAddressbookStoreAdapter(runtimeConfig)
-	listDeployments := usecase.NewListDeployments(runtimeConfig, fileRepository, networkResolver, forkStateStoreAdapter, addressbookStoreAdapter)
+	listDeployments := usecase.NewListDeployments(runtimeConfig, fileRepository, networkResolver, forkStateStoreAdapter)
 	deploymentResolver := resolvers.NewDeploymentResolver(runtimeConfig, fileRepository, selectorAdapter)
 	showDeployment := usecase.NewShowDeployment(runtimeConfig, fileRepository, deploymentResolver, forkStateStoreAdapter)
 	string2 := adapters.ProvideProjectPath(runtimeConfig)

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -119,17 +119,10 @@ type listJSONEntry struct {
 	Fork         bool   `json:"fork,omitempty"`
 }
 
-// listJSONAddressbookEntry represents an addressbook entry in JSON output
-type listJSONAddressbookEntry struct {
-	Name    string `json:"name"`
-	Address string `json:"address"`
-}
-
 // listJSONOutput wraps the JSON output with optional namespace discovery data
 type listJSONOutput struct {
-	Deployments     []listJSONEntry            `json:"deployments"`
-	Addressbook     []listJSONAddressbookEntry `json:"addressbook,omitempty"`
-	OtherNamespaces map[string]int             `json:"otherNamespaces,omitempty"`
+	Deployments     []listJSONEntry `json:"deployments"`
+	OtherNamespaces map[string]int  `json:"otherNamespaces,omitempty"`
 }
 
 // renderListJSON outputs deployments as JSON
@@ -153,18 +146,6 @@ func renderListJSON(result *usecase.DeploymentListResult) error {
 
 	output := listJSONOutput{
 		Deployments: entries,
-	}
-
-	// Include addressbook entries if present
-	if len(result.AddressbookEntries) > 0 {
-		abEntries := make([]listJSONAddressbookEntry, 0, len(result.AddressbookEntries))
-		for _, e := range result.AddressbookEntries {
-			abEntries = append(abEntries, listJSONAddressbookEntry{
-				Name:    e.Name,
-				Address: e.Address,
-			})
-		}
-		output.Addressbook = abEntries
 	}
 
 	// Include other namespaces only when current namespace is empty and others exist

--- a/internal/cli/render/deployments.go
+++ b/internal/cli/render/deployments.go
@@ -52,10 +52,7 @@ func NewDeploymentsRenderer(out io.Writer, color bool) *DeploymentsRenderer {
 
 // RenderDeploymentList renders deployments in the tree-style format
 func (r *DeploymentsRenderer) RenderDeploymentList(result *usecase.DeploymentListResult) error {
-	hasDeployments := len(result.Deployments) > 0
-	hasAddressbook := len(result.AddressbookEntries) > 0
-
-	if !hasDeployments && !hasAddressbook {
+	if len(result.Deployments) == 0 {
 		if len(result.OtherNamespaces) > 0 {
 			r.renderNamespaceDiscoveryHint(result)
 		} else {
@@ -64,15 +61,8 @@ func (r *DeploymentsRenderer) RenderDeploymentList(result *usecase.DeploymentLis
 		return nil
 	}
 
-	if hasDeployments {
-		// Display in tree-style table format
-		r.displayTableFormat(result.Deployments, result.NetworkNames, result.ForkDeploymentIDs)
-	}
-
-	if hasAddressbook {
-		r.renderAddressbookSection(result)
-	}
-
+	// Display in tree-style table format
+	r.displayTableFormat(result.Deployments, result.NetworkNames, result.ForkDeploymentIDs)
 	return nil
 }
 
@@ -593,15 +583,3 @@ func displayWidth(s string) int {
 	return runewidth.StringWidth(s)
 }
 
-// renderAddressbookSection renders the ADDRESSBOOK section in the deployment list output.
-func (r *DeploymentsRenderer) renderAddressbookSection(result *usecase.DeploymentListResult) {
-	fmt.Fprintln(r.out, sectionHeaderStyle.Sprint("ADDRESSBOOK"))
-
-	for _, entry := range result.AddressbookEntries {
-		name := color.New(color.FgYellow, color.Bold).Sprintf("%-24s", entry.Name)
-		addr := addressStyle.Sprint(entry.Address)
-		fmt.Fprintf(r.out, "  %s  %s\n", name, addr)
-	}
-
-	fmt.Fprintln(r.out)
-}

--- a/internal/usecase/list_deployments.go
+++ b/internal/usecase/list_deployments.go
@@ -2,7 +2,6 @@ package usecase
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"sort"
 
@@ -27,17 +26,15 @@ type ListDeployments struct {
 	repo            DeploymentRepository
 	networkResolver NetworkResolver
 	forkState       ForkStateStore
-	addressbook     AddressbookRepository
 }
 
 // NewListDeployments creates a new ListDeployments use case
-func NewListDeployments(cfg *config.RuntimeConfig, repo DeploymentRepository, networkResolver NetworkResolver, forkState ForkStateStore, addressbook AddressbookRepository) *ListDeployments {
+func NewListDeployments(cfg *config.RuntimeConfig, repo DeploymentRepository, networkResolver NetworkResolver, forkState ForkStateStore) *ListDeployments {
 	return &ListDeployments{
 		config:          cfg,
 		repo:            repo,
 		networkResolver: networkResolver,
 		forkState:       forkState,
-		addressbook:     addressbook,
 	}
 }
 
@@ -102,9 +99,6 @@ func (uc *ListDeployments) Run(ctx context.Context, params ListDeploymentsParams
 	if len(deployments) == 0 {
 		result.OtherNamespaces = uc.discoverOtherNamespaces(ctx)
 	}
-
-	// Load addressbook entries for the current chain
-	result.AddressbookEntries = uc.loadAddressbookEntries(ctx)
 
 	return result, nil
 }
@@ -261,35 +255,3 @@ func (uc *ListDeployments) findNetworkName(ctx context.Context, chainID uint64) 
 	return ""
 }
 
-// loadAddressbookEntries loads sorted addressbook entries for the current chain.
-// Returns nil if no network is configured or the addressbook is empty/unreadable.
-func (uc *ListDeployments) loadAddressbookEntries(ctx context.Context) []domain.AddressbookEntry {
-	if uc.config.Network == nil {
-		return nil
-	}
-
-	ab, err := uc.addressbook.Load(ctx)
-	if err != nil {
-		return nil
-	}
-
-	chainKey := fmt.Sprintf("%d", uc.config.Network.ChainID)
-	chain := ab[chainKey]
-	if len(chain) == 0 {
-		return nil
-	}
-
-	entries := make([]domain.AddressbookEntry, 0, len(chain))
-	for name, addr := range chain {
-		entries = append(entries, domain.AddressbookEntry{
-			Name:    name,
-			Address: addr,
-		})
-	}
-
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].Name < entries[j].Name
-	})
-
-	return entries
-}

--- a/internal/usecase/list_deployments_test.go
+++ b/internal/usecase/list_deployments_test.go
@@ -67,20 +67,6 @@ func (m *mockForkState) Delete(_ context.Context) error {
 	return nil
 }
 
-// mockAddressbookRepo implements AddressbookRepository for testing (always returns empty)
-type mockAddressbookRepo struct{}
-
-func (m *mockAddressbookRepo) Load(_ context.Context) (domain.Addressbook, error) {
-	return make(domain.Addressbook), nil
-}
-
-func (m *mockAddressbookRepo) Save(_ context.Context, _ domain.Addressbook) error {
-	return nil
-}
-
-func (m *mockAddressbookRepo) GetPath() string {
-	return ""
-}
 
 func TestListDeployments_OtherNamespaces(t *testing.T) {
 	t.Run("empty namespace with others available", func(t *testing.T) {
@@ -102,7 +88,7 @@ func TestListDeployments_OtherNamespaces(t *testing.T) {
 			Network:   &config.Network{Name: "anvil-31337", ChainID: 31337},
 		}
 
-		uc := NewListDeployments(cfg, repo, &mockNetworkResolver{}, &mockForkState{}, &mockAddressbookRepo{})
+		uc := NewListDeployments(cfg, repo, &mockNetworkResolver{}, &mockForkState{})
 		result, err := uc.Run(context.Background(), ListDeploymentsParams{})
 
 		require.NoError(t, err)
@@ -130,7 +116,7 @@ func TestListDeployments_OtherNamespaces(t *testing.T) {
 			Network:   &config.Network{Name: "anvil-31337", ChainID: 31337},
 		}
 
-		uc := NewListDeployments(cfg, repo, &mockNetworkResolver{}, &mockForkState{}, &mockAddressbookRepo{})
+		uc := NewListDeployments(cfg, repo, &mockNetworkResolver{}, &mockForkState{})
 		result, err := uc.Run(context.Background(), ListDeploymentsParams{})
 
 		require.NoError(t, err)
@@ -153,7 +139,7 @@ func TestListDeployments_OtherNamespaces(t *testing.T) {
 			Network:   &config.Network{Name: "anvil-31337", ChainID: 31337},
 		}
 
-		uc := NewListDeployments(cfg, repo, &mockNetworkResolver{}, &mockForkState{}, &mockAddressbookRepo{})
+		uc := NewListDeployments(cfg, repo, &mockNetworkResolver{}, &mockForkState{})
 		result, err := uc.Run(context.Background(), ListDeploymentsParams{})
 
 		require.NoError(t, err)
@@ -180,7 +166,7 @@ func TestListDeployments_OtherNamespaces(t *testing.T) {
 			Network:   &config.Network{Name: "anvil-31337", ChainID: 31337},
 		}
 
-		uc := NewListDeployments(cfg, repo, &mockNetworkResolver{}, &mockForkState{}, &mockAddressbookRepo{})
+		uc := NewListDeployments(cfg, repo, &mockNetworkResolver{}, &mockForkState{})
 		result, err := uc.Run(context.Background(), ListDeploymentsParams{})
 
 		require.NoError(t, err)
@@ -210,7 +196,7 @@ func TestListDeployments_OtherNamespaces(t *testing.T) {
 			// Network is nil - no chain filter
 		}
 
-		uc := NewListDeployments(cfg, repo, &mockNetworkResolver{}, &mockForkState{}, &mockAddressbookRepo{})
+		uc := NewListDeployments(cfg, repo, &mockNetworkResolver{}, &mockForkState{})
 		result, err := uc.Run(context.Background(), ListDeploymentsParams{})
 
 		require.NoError(t, err)
@@ -241,7 +227,7 @@ func TestListDeployments_OtherNamespaces(t *testing.T) {
 			Network:   &config.Network{Name: "anvil-31337", ChainID: 31337},
 		}
 
-		uc := NewListDeployments(cfg, repo, &mockNetworkResolver{}, &mockForkState{}, &mockAddressbookRepo{})
+		uc := NewListDeployments(cfg, repo, &mockNetworkResolver{}, &mockForkState{})
 		result, err := uc.Run(context.Background(), ListDeploymentsParams{})
 
 		require.NoError(t, err)

--- a/internal/usecase/ports.go
+++ b/internal/usecase/ports.go
@@ -98,9 +98,8 @@ type DeploymentListResult struct {
 	Summary            DeploymentSummary
 	NetworkNames       map[uint64]string       // Map of chain ID to network name
 	ForkDeploymentIDs  map[string]bool          // Set of deployment IDs added during fork mode (nil if fork not active)
-	OtherNamespaces    map[string]int           // Other namespaces with deployment counts (nil when deployments found)
-	AddressbookEntries []domain.AddressbookEntry // Addressbook entries for the current chain
-	CurrentNamespace   string                   // Current namespace for display in hints
+	OtherNamespaces  map[string]int // Other namespaces with deployment counts (nil when deployments found)
+	CurrentNamespace string         // Current namespace for display in hints
 	CurrentNetwork     string                   // Current network name for display in hints (empty if not set)
 	CurrentChainID     uint64                   // Current chain ID for display in hints (0 if not set)
 }

--- a/test/integration/addressbook_test.go
+++ b/test/integration/addressbook_test.go
@@ -120,13 +120,9 @@ func TestAddressbookCommand(t *testing.T) {
 				require.True(t, ok, "expected deployments array")
 				require.Len(t, entries, 1)
 
-				// Should have addressbook
-				ab, ok := result["addressbook"].([]interface{})
-				require.True(t, ok, "expected addressbook array")
-				require.Len(t, ab, 1)
-				abEntry := ab[0].(map[string]interface{})
-				assert.Equal(t, "WETH", abEntry["name"])
-				assert.Equal(t, "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", abEntry["address"])
+				// Should NOT have addressbook (removed from list output)
+				_, hasAB := result["addressbook"]
+				assert.False(t, hasAB, "addressbook should not be in list JSON output")
 			},
 		},
 	}

--- a/test/testdata/golden/integration/TestAddressbookCommand/list_with_addressbook_entries/commands.golden
+++ b/test/testdata/golden/integration/TestAddressbookCommand/list_with_addressbook_entries/commands.golden
@@ -6,5 +6,3 @@
   Counter     0x74148047D6bDf624C94eFc07F60cEE7b6052FB29   e[-]  s[-]  b[-]    <TIMESTAMP>   
 
 Total deployments: 1
-ADDRESSBOOK
-  WETH                      0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2


### PR DESCRIPTION
## Summary
- Removes addressbook entries from `treb list` output (both table and JSON formats)
- Addressbook is now only accessible via the dedicated `treb addressbook list` command
- Keeps deployment listing focused on deployments only

## Test plan
- [x] Unit tests updated and passing
- [x] Integration tests updated (golden files + JSON assertion)
- [x] Lint passing
- [x] All `TestListCommand` tests passing
- [x] All `TestAddressbookCommand` tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Addressbook information is no longer displayed in deployment list output
  * JSON output structure simplified by removing addressbook field

<!-- end of auto-generated comment: release notes by coderabbit.ai -->