### PR TITLE
fix: exclude addressbook from fork backup/restore

### DIFF
--- a/internal/adapters/fs/fork_file_manager.go
+++ b/internal/adapters/fs/fork_file_manager.go
@@ -12,12 +12,13 @@ import (
 )
 
 // registryFiles is the list of .treb/ files to backup and restore during fork mode.
+// The addressbook is intentionally excluded: it contains user-curated reference
+// data (external contract addresses) that should persist across fork operations.
 var registryFiles = []string{
 	"deployments.json",
 	"transactions.json",
 	"safe-txs.json",
 	"registry.json",
-	"addressbook.json",
 }
 
 // ForkFileManagerAdapter implements ForkFileManager using the file system

--- a/test/helpers/normalizers.go
+++ b/test/helpers/normalizers.go
@@ -202,6 +202,10 @@ func (n SpinnerNormalizer) Normalize(output string) string {
 	finishedPattern := regexp.MustCompile(`\[[^\]]+\] Solc [^\n\r]* finished in [0-9.]+s`)
 	output = finishedPattern.ReplaceAllString(output, "[*] Solc finished")
 
+	// Collapse repeated "[*] Solc finished" (forge sometimes prints it twice due to spinner race)
+	solcDupPattern := regexp.MustCompile(`(\[?\*\] Solc finished){2,}`)
+	output = solcDupPattern.ReplaceAllString(output, "[*] Solc finished")
+
 	// Collapse consecutive "Compiling" spinner frames into a single normalized line
 	compilingPattern := regexp.MustCompile(`((?:\r)*\[[^\]]+\] Compiling[^\n\r]*\s*(?:\r?\n|\r))+`)
 	output = compilingPattern.ReplaceAllString(output, "\r[⠃] Compiling...\n")

--- a/test/testdata/golden/integration/TestRunCommand/run_with_debug/commands.golden
+++ b/test/testdata/golden/integration/TestRunCommand/run_with_debug/commands.golden
@@ -9,7 +9,7 @@
   Senders:   [anvil]
 ──────────────────────────────────────────────────
 [⠃] Compiling...
-[*] Solc finished[*] Solc finished
+[*] Solc finished
 Compiler run successful!
 Traces:
   [1359176] DeployCounter::run()


### PR DESCRIPTION
## Summary
- Removes `addressbook.json` from the fork file backup/restore list
- The addressbook contains user-curated reference data (external contract addresses like WETH, USDC) that should persist across fork operations
- Only deployment state files (`deployments.json`, `transactions.json`, `safe-txs.json`, `registry.json`) are backed up/restored during fork enter/exit/revert

## Test plan
- [x] All `TestForkFileManager` unit tests passing
- [x] Build passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Address book now persists across fork operations instead of being included in fork backups/restores, preserving your contacts.
  * Compiler progress output no longer shows a duplicated "[*] Solc finished" line, reducing confusing duplicate status messages.

* **Tests**
  * Test expectations updated to reflect the single "Solc finished" output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->