### PR TITLE
fix: include oz_governor proposer in transitive sender resolution

### DIFF
--- a/internal/config/senders.go
+++ b/internal/config/senders.go
@@ -64,15 +64,25 @@ func (m *SendersManager) BuildSenderScriptConfig(
 		return nil, fmt.Errorf("can not use ledger and trezor senders in the same script, configure @custom:senders")
 	}
 
-	var safeSigners []string
+	// Collect transitive sender dependencies: senders not in @custom:senders but
+	// referenced by declared senders (e.g. a safe's signer or a governor's proposer).
+	// These must be included in SENDER_CONFIGS so the Solidity registry can look them up.
+	var transitiveSenders []string
 	if m.config != nil && m.config.Senders != nil {
 		for _, senderKey := range senders {
-			if sender, exists := m.config.Senders[senderKey]; exists && sender.Type == "safe" {
-				safeSigners = append(safeSigners, sender.Signer)
+			sender, exists := m.config.Senders[senderKey]
+			if !exists {
+				continue
+			}
+			switch sender.Type {
+			case "safe":
+				transitiveSenders = append(transitiveSenders, sender.Signer)
+			case "oz_governor":
+				transitiveSenders = append(transitiveSenders, sender.Proposer)
 			}
 		}
 	}
-	signersHWConfig := m.getSendersHWConfig(safeSigners)
+	signersHWConfig := m.getSendersHWConfig(transitiveSenders)
 
 	if signersHWConfig.UseLedger && executionHWConfig.UseLedger {
 		return nil, fmt.Errorf("can not use ledger in both main sender and safe signer, configure @custom:senders")
@@ -82,9 +92,9 @@ func (m *SendersManager) BuildSenderScriptConfig(
 		return nil, fmt.Errorf("can not use ledger in both main sender and safe signer, configure @custom:senders")
 	}
 
-	sort.Strings(safeSigners)
+	sort.Strings(transitiveSenders)
 	sort.Strings(senders)
-	allSenders := append(slices.Clone(safeSigners), senders...)
+	allSenders := append(slices.Clone(transitiveSenders), senders...)
 
 	var senderInitConfigs []config.SenderInitConfig
 	if senderInitConfigs, err = m.buildSenderInitConfigs(allSenders); err != nil {


### PR DESCRIPTION
## Summary

- **Bug**: When a script uses an `oz_governor` sender (e.g. `@custom:senders deployer, governor`), the governor's `proposer` account (e.g. `dev-pk`) was not included in the encoded `SENDER_CONFIGS` passed to Solidity. This caused `OZGovernorSender.initialize()` to revert with `InvalidOZGovernorConfig` because it couldn't find the proposer in the sender registry.
- **Root cause**: `BuildSenderScriptConfig` resolved transitive sender dependencies for `safe` senders (including their `signer`), but did not do the same for `oz_governor` senders and their `proposer` field.
- **Fix**: Extended the transitive dependency resolution to also handle `oz_governor` senders by including their `proposer`, using the same pattern already in place for `safe` signers.

## Details

The error manifested as:

```
execution reverted: custom error 0x8fede2fc: governor
```

This is `InvalidOZGovernorConfig("governor")` from `OZGovernorSender.sol:112`.

The flow:

1. CLI reads `@custom:senders deployer, governor` from the script's natspec
2. CLI resolves each sender through the namespace config and builds `SenderInitConfig` structs
3. CLI ABI-encodes these into the `SENDER_CONFIGS` env var
4. Solidity deserializes `SENDER_CONFIGS` and registers each sender by `keccak256(name)` in the `Senders` registry
5. `OZGovernorSender.initialize()` decodes the governor's config to find `proposerName = "dev-pk"`, then calls `Senders.get(keccak256("dev-pk"))` to look up the proposer
6. **`dev-pk` was never registered** — only `deployer` was (which uses the same underlying private key but is registered under a different name)
7. The lookup returns an uninitialized slot with `senderType = 0x0`, which fails the type validation → revert

The fix adds `oz_governor` to the same `switch` block that already handles `safe` signers, so `dev-pk` (or whatever the proposer is) gets included as a transitive dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sender dependency resolution to collect all transitive dependencies instead of only direct Safe signers, improving sender configuration completeness
  * Enhanced hardware wallet setup to properly incorporate governor proposer references in addition to signer references
  * Improved sender initialization to ensure all resolved transitive dependencies are correctly included and sorted in the final script configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->